### PR TITLE
Restore file timestamps when extracting

### DIFF
--- a/src/core/FatDate.cpp
+++ b/src/core/FatDate.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <iostream>
 #include <string>
+#include <time.h>
 
 #include <FatUtils.h>
 #include "FatDate.h"
@@ -32,4 +33,28 @@ string FatDate::pretty()
     sprintf(buffer, "%d/%d/%04d %02d:%02d:%02d", d, m, y, h, i, s);
 
     return string(buffer);
+}
+
+/**
+ * Returns date as a number of seconds elapsed since the Epoch,
+ * 1970-01-01 00:00:00 +0000 (UTC). FAT dates are considered to be in the
+ * current timezone not in UTC. So what this function returns depends on
+ * the current timezone.
+ */
+time_t FatDate::timestamp() const
+{
+    struct tm tm;
+    tm.tm_sec = s;         // Seconds (0-60)
+    tm.tm_min = i;         // Minutes (0-59)
+    tm.tm_hour = h;        // Hours (0-23)
+    tm.tm_mday = d;        // Day of the month (1-31)
+    tm.tm_mon = m - 1;     // Month (0-11)
+    tm.tm_year = y - 1900; // Year - 1900
+
+    // A negative value of tm_isdst means that mktime() should (use timezone
+    // information and system databases to) attempt to determine whether DST
+    // is in effect at the specified time.
+    tm.tm_isdst = -1;      // Daylight saving time
+
+    return mktime(&tm);
 }

--- a/src/core/FatDate.h
+++ b/src/core/FatDate.h
@@ -2,6 +2,7 @@
 #define _FATCAT_FATDATE_H
 
 #include <string>
+#include <time.h>
 
 using namespace std;
 
@@ -15,6 +16,7 @@ class FatDate
         int y, m, d;
 
         string pretty();
+        time_t timestamp() const;
 };
 
 #endif // _FATCAT_FATDATE_H


### PR DESCRIPTION
It's convenient that an archiving utility restores file timestamps
when extracting files. See no reason for fatcat not doing so.