### PR TITLE
Don't skip files that have no archive attribute set

### DIFF
--- a/src/core/FatEntry.cpp
+++ b/src/core/FatEntry.cpp
@@ -85,10 +85,6 @@ bool FatEntry::printable(unsigned char c)
 
 bool FatEntry::isCorrect()
 {
-    if (attributes && !(attributes&FAT_ATTRIBUTES_DIR) && !(attributes&FAT_ATTRIBUTES_FILE)) {
-        return false;
-    }
-
     if (isDirectory() && cluster == 0 && getFilename()!="..") {
         return false;
     }

--- a/src/core/FatEntry.h
+++ b/src/core/FatEntry.h
@@ -20,7 +20,7 @@ using namespace std;
 #define FAT_ATTRIBUTES_HIDE     (1<<1)
 #define FAT_ATTRIBUTES_DIR      (1<<4)
 #define FAT_ATTRIBUTES_LONGFILE (0xf)
-#define FAT_ATTRIBUTES_FILE     (0x20)
+#define FAT_ATTRIBUTES_ARCHIVE  (0x20)
 
 // Prefix used for erased files
 #define FAT_ERASED                  0xe5


### PR DESCRIPTION
There is nothing incorrent for the file not to have the archive attribute set while having some other attributes.

This will fix skipping hidden/system files that don't have the archive attribute set.