### PR TITLE
Output 8DOT3 short filenames whenever possible

### DIFF
--- a/src/core/FatEntry.cpp
+++ b/src/core/FatEntry.cpp
@@ -34,22 +34,27 @@ string FatEntry::getFilename()
     if (longName != "") {
         return longName;
     } else {
-        string name;
-        string ext = trim(shortName.substr(8,3));
-        string base = trim(shortName.substr(0,8));
-
-        if (isErased()) {
-            base = base.substr(1);
-        }
-
-        name = base;
-
-        if (ext != "") {
-            name += "." + ext;
-        }
-
-        return name;
+        return getShortFilename();
     }
+}
+
+string FatEntry::getShortFilename()
+{
+    string name;
+    string ext = trim(shortName.substr(8,3));
+    string base = trim(shortName.substr(0,8));
+
+    if (isErased()) {
+        base = base.substr(1);
+    }
+
+    name = base;
+
+    if (ext != "") {
+        name += "." + ext;
+    }
+
+    return name;
 }
         
 bool FatEntry::isDirectory()

--- a/src/core/FatEntry.h
+++ b/src/core/FatEntry.h
@@ -31,6 +31,7 @@ class FatEntry
         FatEntry();
 
         string getFilename();
+        string getShortFilename();
         bool isDirectory();
         bool isHidden();
         bool isErased();

--- a/src/core/FatSystem.cpp
+++ b/src/core/FatSystem.cpp
@@ -510,9 +510,11 @@ void FatSystem::list(vector<FatEntry> &entries)
             }
 
             string name = entry.getFilename();
+            string shrtname = entry.getShortFilename();
 
             cout << "\"EditDate\":\"" << entry.changeDate.isoFormat() << "\",";
             cout << "\"Name\":\"" << name << "\",";
+            cout << "\"8DOT3Name\":\"" << shrtname << "\",";
             cout << "\"Cluster\":" << entry.cluster << ",";
 
             if (!entry.isDirectory()) {
@@ -557,8 +559,13 @@ void FatSystem::list(vector<FatEntry> &entries)
                 name += "/";
             }
 
+            string shrtname = entry.getShortFilename();
+            if (name.compare(shrtname)) {
+                name += " (" + shrtname + ")";
+            }
+
             printf(" %s ", entry.changeDate.pretty().c_str());
-            printf(" %-30s", name.c_str());
+            printf(" %-50s", name.c_str());
 
             printf(" c=%u", entry.cluster);
 


### PR DESCRIPTION
In some cases it is useful to know the short (8DOT3) filename for debugging.

In case of the default output format, the 8DOT3 short file name is printed, when directories are listed. For the JSON-formatter, a new value »8DOT3Name« is introduced, containing the short file name.

This is how it looks with both formatters:

![image](https://user-images.githubusercontent.com/591773/79621317-32828e00-8113-11ea-90b7-4ba7b711a553.png)

I would have extended the unit tests but unfortunately I was not able to get phpunit up and running. Are there any special requirements I need to install?