### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: cpp
+arch:
+  - amd64
+  - ppc64le
 
 compiler:
     - gcc


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/fatcat/builds/188598618 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!