### PR TITLE
fix getting address of cluster 0

### DIFF
--- a/src/core/FatSystem.cpp
+++ b/src/core/FatSystem.cpp
@@ -312,14 +312,13 @@ bool FatSystem::validCluster(unsigned int cluster)
 
 unsigned long long FatSystem::clusterAddress(unsigned int cluster, bool isRoot)
 {
-    if (type == FAT32 || !isRoot) {
-        cluster -= 2;
-    }
-
     unsigned long long addr = (dataStart + bytesPerSector*sectorsPerCluster*cluster);
 
     if (type == FAT16 && !isRoot) {
         addr += rootEntries * FAT_ENTRY_SIZE;
+    }
+    if (type == FAT32 || !isRoot) {
+        addr -= bytesPerSector*sectorsPerCluster*2;
     }
 
     return addr;


### PR DESCRIPTION
Due to the changes in 530b663 to suuport larger disk the math to covert a
to an address underflows then it cast to a wider int without sign extention
leaving a bit set in the middle of the number.

This change moves the subtraction to happen after the other additions
and widening thus prevting any underflow issues.

fixes #30

