### PR TITLE
Fix Heap Corruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 **.swp
 test
+*.bak
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(fatcat)
 
 OPTION(DEFINE_WIN "Compiling windows" OFF)

--- a/src/core/FatSystem.cpp
+++ b/src/core/FatSystem.cpp
@@ -239,7 +239,6 @@ unsigned int FatSystem::nextCluster(unsigned int cluster, int fat)
                 next = next >> 4;
             }
             next &= 0xfff;
-            cout << next << endl;
             if (next >= 0xff0) {
                 return FAT_LAST;
             } else {

--- a/src/core/FatSystem.cpp
+++ b/src/core/FatSystem.cpp
@@ -102,7 +102,6 @@ int FatSystem::readData(unsigned long long address, char *buffer, int size)
             size -= n;
         }
     } while ((size>0) && (n>0));
-
     return n;
 }
 
@@ -240,6 +239,7 @@ unsigned int FatSystem::nextCluster(unsigned int cluster, int fat)
                 next = next >> 4;
             }
             next &= 0xfff;
+            cout << next << endl;
             if (next >= 0xff0) {
                 return FAT_LAST;
             } else {

--- a/src/core/FatSystem.cpp
+++ b/src/core/FatSystem.cpp
@@ -212,7 +212,6 @@ unsigned int FatSystem::nextCluster(unsigned int cluster, int fat)
     }
 
     if (cacheEnabled) {
-        cout << "[Debug] Using cache!" << endl;
         return cache[cluster];
     }
 
@@ -605,13 +604,13 @@ void FatSystem::readFile(unsigned int cluster, unsigned int size, FILE *f, bool 
         int toRead = size;
         if (toRead > bytesPerCluster || size < 0) {
             toRead = bytesPerCluster;
-        }
+    }
 #ifndef __WIN__
-        char buffer[bytesPerCluster];
+    char buffer[bytesPerCluster];
 #else
-                char *buffer = new char[bytesPerCluster];
-                __try
-                {
+    char *buffer = new char[bytesPerCluster];
+    __try
+    {
 #endif
         readData(clusterAddress(cluster), buffer, toRead);
 
@@ -852,11 +851,7 @@ FatEntry FatSystem::rootEntry()
 
 bool FatSystem::freeCluster(unsigned int cluster)
 {
-    __try {
-        return nextCluster(cluster) == 0;
-    } __finally {
-        cout << "[Debug] Yeah This part works lol" << endl;
-    }
+    return nextCluster(cluster) == 0;
 }
 
 void FatSystem::computeStats()
@@ -895,7 +890,11 @@ void FatSystem::rewriteUnallocated(bool random)
                     buffer[i] = 0x0;
                 }
             }
+            #ifndef __WIN__
             writeData(clusterAddress(cluster), buffer, sizeof(buffer));
+            #else
+            writeData(clusterAddress(cluster), buffer, sizeof(*buffer));
+            #endif
             total++;
 #ifdef __WIN__
             }


### PR DESCRIPTION
<h1>Why this pull request exists</h1>

Due to windows using heap instead of stack, `sizeof(buffer)` returns the size of the pointer, **not** the buffer itself.
This causes heap corruption.

The pull request fixes #39
(Or at least part of it)